### PR TITLE
Migrated sample project from 2.2 to 3.1 LTS

### DIFF
--- a/samples/MVCSample/MVCSample.Bootstrap3.csproj
+++ b/samples/MVCSample/MVCSample.Bootstrap3.csproj
@@ -1,15 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
-  </ItemGroup>
-
+  
   <ItemGroup>
     <ProjectReference Include="..\..\src\CheckBoxList\CheckBoxList.Core.csproj" />
   </ItemGroup>

--- a/samples/MVCSample/Startup.cs
+++ b/samples/MVCSample/Startup.cs
@@ -17,7 +17,7 @@ namespace MVCSample.Bootstrap3
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddMvc();
+            services.AddMvc(options => options.EnableEndpointRouting = false);
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.


### PR DESCRIPTION
**Migrated sample project which was using deprecated dotnet core version 2.2  to LTS 3.1**
#### As a part of that removed reference to  Microsoft.AspNetCore.App and Microsoft.AspNetCore.Razor.Design which are not required any more as of 3.1. And to use MVC we gotta disable endpoint routing.

